### PR TITLE
Create an Octopus Deploy release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         uses: OctopusDeploy/create-release-action@v3.2.2
         with:
           server: https://deploy.particular.net
-          api_key: ${{ inputs.octopus-deploy-api-key }}
+          api_key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
           project: ServiceControl.Connector.MassTransit
           release_number: ${{env.MinVerVersion}}
           package_version: ${{env.MinVerVersion}}


### PR DESCRIPTION
Release workflow does not create any package artifacts but does need to create a release in Octopus Deploy. This PR creates a release copied from https://github.com/Particular/push-octopus-package-action/