### PR TITLE
Make `ServiceControl.Retry.AcknowledgementQueue` value MT addressable

### DIFF
--- a/src/ServiceControl.Connector.MassTransit.AzureServiceBus/AzureServiceBusMassTransitFailureAdapter.cs
+++ b/src/ServiceControl.Connector.MassTransit.AzureServiceBus/AzureServiceBusMassTransitFailureAdapter.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 using NServiceBus.Transport;
 using NServiceBus.Transport.AzureServiceBus.Experimental;
 
-class AzureServiceBusMassTransitFailureAdapter(
+sealed class AzureServiceBusMassTransitFailureAdapter(
     ILogger<MassTransitFailureAdapter> logger,
     MassTransitConverter mtConverter,
     Configuration configuration

--- a/src/ServiceControl.Connector.MassTransit.RabbitMQ/AdapterRabbitMqConfiguration.cs
+++ b/src/ServiceControl.Connector.MassTransit.RabbitMQ/AdapterRabbitMqConfiguration.cs
@@ -10,5 +10,6 @@ public static class AdapterRabbitMqConfiguration
             connectionString,
             enableDelayedDelivery: false
         )));
+        services.AddSingleton<MassTransitFailureAdapter, RabbitMQMassTransitFailureAdapter>();
     }
 }

--- a/src/ServiceControl.Connector.MassTransit.RabbitMQ/RabbitMQMassTransitFailureAdapter.cs
+++ b/src/ServiceControl.Connector.MassTransit.RabbitMQ/RabbitMQMassTransitFailureAdapter.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.Logging;
+
+sealed class RabbitMQMassTransitFailureAdapter(
+    ILogger<MassTransitFailureAdapter> logger,
+    MassTransitConverter mtConverter,
+    Configuration configuration
+)
+    : MassTransitFailureAdapter(
+        logger,
+        mtConverter,
+        configuration
+    )
+{
+    protected override string QueuePrefix => "exchange:";
+}

--- a/src/ServiceControl.Connector.MassTransit/MassTransitConverter.cs
+++ b/src/ServiceControl.Connector.MassTransit/MassTransitConverter.cs
@@ -21,11 +21,6 @@ public class MassTransitConverter(ILogger<MassTransitConverter> logger)
             {
                 headers.Remove(key);
             }
-
-            if (key.StartsWith("ServiceControl."))
-            {
-                headers.Remove(key);
-            }
         }
     }
 


### PR DESCRIPTION
Patch the value of the `ServiceControl.Retry.AcknowledgementQueue` to contain a value that is addressable by MassTransit.