### PR TITLE
Do not validate `NServiceBus.MessageId` header in the custom SQS receiver

### DIFF
--- a/src/ServiceControl.Connector.MassTransit.AmazonSQS/CustomSqsReceiver.cs
+++ b/src/ServiceControl.Connector.MassTransit.AmazonSQS/CustomSqsReceiver.cs
@@ -22,20 +22,20 @@ class CustomSqsReceiver(IMessageReceiver receiver) : IMessageReceiver
 
         foreach (var attribute in nativeMessage.MessageAttributes)
         {
+            if (attribute.Key == Headers.MessageId)
+            {
+                //HINT: SQS messages retried from ServiceControl will have NServiceBus.MessageId value both in the
+                //      message attribute of the native message and in the headers collection in the message body
+                //      these values are different, but that is not a problem as it's not used in any way by the MassTransit consumers
+                return;
+            }
+
             AddIfNotExistThrowIfValueMismatch(messageContext, headers, attribute);
         }
     }
 
     static void AddIfNotExistThrowIfValueMismatch(MessageContext messageContext, Dictionary<string, string> headers, KeyValuePair<string, MessageAttributeValue> attribute)
     {
-        if (attribute.Key == Headers.MessageId)
-        {
-            //HINT: SQS messages retried from ServiceControl will have NServiceBus.MessageId value both in the
-            //      message attribute of the native message and in the headers collection in the message body
-            //      these values are different, but that is not a problem as it's not used in any way by the MassTransit consumers
-            return;
-        }
-
         if (headers.TryGetValue(attribute.Key, out var existingHeaderValue))
         {
             if (existingHeaderValue != attribute.Value.StringValue)


### PR DESCRIPTION
Service Control when retrying messages sets `NServiceBus.MessageId` SQS message attribute with the value equal to the native SQS message id that was ingested from the `error` queue. When such a message is received by the custom SQS receiver in the connector, this value does not equal the `NServiceBus.MessageId` set in the body of the wrapped SQS message. 

This difference is not important from the connector perspective as the `NServiceBus.MessageId` attribute never gets to a MassTransit consumer.