### PR TITLE
Fix startup issue with AzureServiceBus

### DIFF
--- a/src/ServiceControl.Connector.MassTransit.AcceptanceTests/Shared/Support/ConnectorComponent.cs
+++ b/src/ServiceControl.Connector.MassTransit.AcceptanceTests/Shared/Support/ConnectorComponent.cs
@@ -39,6 +39,7 @@ public class ConnectorComponent<TContext>(string name, string errorQueue, string
                     services.AddSingleton<ReceiverFactory>();
                     services.AddHostedService<Service>();
                     services.AddSingleton<IProvisionQueues, ProvisionQueues>();
+                    services.AddSingleton(TimeProvider.System);
                     transportConfig.ConfigureTransportForConnector(services, hostContext.Configuration);
                 });
 

--- a/src/ServiceControl.Connector.MassTransit.Host/HostApplicationBuilderExtensions.cs
+++ b/src/ServiceControl.Connector.MassTransit.Host/HostApplicationBuilderExtensions.cs
@@ -32,7 +32,8 @@ static class HostApplicationBuilderExtensions
             .AddSingleton<MassTransitConverter>()
             .AddSingleton<MassTransitFailureAdapter>()
             .AddSingleton<ReceiverFactory>()
-            .AddSingleton<IProvisionQueues, ProvisionQueues>();
+            .AddSingleton<IProvisionQueues, ProvisionQueues>()
+            .AddSingleton(TimeProvider.System);
 
         if (command != Command.Setup)
         {

--- a/src/ServiceControl.Connector.MassTransit/Service.cs
+++ b/src/ServiceControl.Connector.MassTransit/Service.cs
@@ -13,14 +13,12 @@ public class Service(
     MassTransitFailureAdapter adapter,
     Configuration configuration,
     ReceiverFactory receiverFactory,
-    IHostApplicationLifetime hostApplicationLifetime
-) : IHostedService
+    IHostApplicationLifetime hostApplicationLifetime,
+    TimeProvider timeProvider
+) : BackgroundService
 {
-    readonly CancellationTokenSource StopCancellationTokenSource = new();
-    Task? loopTask;
-
     TransportInfrastructure? infrastructure;
-    HashSet<string>? massTransitErrorQueues = [];
+    HashSet<string> massTransitErrorQueues = [];
 
     async Task<HashSet<string>> GetReceiveQueues(CancellationToken cancellationToken)
     {
@@ -44,56 +42,56 @@ public class Service(
         return [];
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        var version = System.Diagnostics.FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly()!.Location).ProductVersion!;
-        logger.LogInformation("ServiceControl.Connector.MassTransit {Version}", version);
+        logger.LogInformation($"Starting {nameof(Service)}");
 
-        loopTask = Loop(StopCancellationTokenSource.Token);
-
-        return Task.CompletedTask;
-    }
-
-    async Task Loop(CancellationToken cancellationToken)
-    {
         try
         {
-            while (!cancellationToken.IsCancellationRequested)
+            using PeriodicTimer timer = new(configuration.QueueScanInterval, timeProvider);
+            do
             {
-                var newData = await GetReceiveQueues(cancellationToken);
-
-                var errorQueuesAreNotTheSame = !newData.SetEquals(massTransitErrorQueues!);
-
-                if (errorQueuesAreNotTheSame)
+                try
                 {
-                    logger.LogInformation("Changes detected, restarting");
-                    await StopReceiving(cancellationToken);
-                    massTransitErrorQueues = newData;
-                    await StartReceiving(cancellationToken);
-                }
+                    var newData = await GetReceiveQueues(cancellationToken);
+                    var errorQueuesAreTheSame = newData.SetEquals(massTransitErrorQueues);
 
-                await Task.Delay(configuration.QueueScanInterval, cancellationToken);
-            }
+                    if (errorQueuesAreTheSame)
+                    {
+                        logger.LogInformation("No changes detected for Masstransit queues");
+                        continue;
+                    }
+
+                    massTransitErrorQueues = newData;
+
+                    if (infrastructure is not null)
+                    {
+                        logger.LogInformation("Changes detected, restarting");
+
+                        await StopReceiving(CancellationToken.None);
+                    }
+
+                    await StartReceiving(CancellationToken.None);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+                {
+                    logger.LogError(ex, "Failed to shoveling Masstransit messages");
+                }
+            } while (await timer.WaitForNextTickAsync(cancellationToken));
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            logger.LogInformation("Shutting down initiated by host");
-        }
-        catch (Exception e)
-        {
-            logger.LogCritical(e, "Failure");
-            hostApplicationLifetime.StopApplication();
-        }
-    }
+            logger.LogInformation($"Stopping {nameof(Service)}");
 
-    public async Task StopAsync(CancellationToken cancellationToken)
-    {
-        await StopCancellationTokenSource.CancelAsync();
-        if (loopTask != null)
-        {
-            await loopTask;
+            try
+            {
+                await StopReceiving(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to stop all the receivers");
+            }
         }
-        await StopReceiving(cancellationToken);
     }
 
     async Task StartReceiving(CancellationToken cancellationToken)
@@ -121,9 +119,9 @@ public class Service(
             )
         };
 
-        foreach (var massTransitErrorQueue in massTransitErrorQueues!)
+        foreach (var massTransitErrorQueue in massTransitErrorQueues)
         {
-            logger.LogInformation("listening to: {InputQueue}", massTransitErrorQueue);
+            logger.LogInformation("Ingesting messages from {InputQueue}", massTransitErrorQueue);
             receiveSettings.Add(receiverFactory.Create(massTransitErrorQueue, configuration.ErrorQueue));
         }
 
@@ -140,7 +138,7 @@ public class Service(
 
         OnMessage forwardMessage = async (messageContext, token) =>
         {
-            using var scope = logger.BeginScope("FORWARD {ReceiveAddress} {NativeMessageId}", messageContext.ReceiveAddress, messageContext.NativeMessageId);
+            logger.LogInformation("FORWARD {ReceiveAddress} {NativeMessageId}", messageContext.ReceiveAddress, messageContext.NativeMessageId);
             TransportOperation operation;
             try
             {
@@ -150,13 +148,12 @@ public class Service(
             {
                 throw new ConversionException("Conversion to ServiceControl failed", e);
             }
-
             await messageDispatcher.Dispatch(new TransportOperations(operation), messageContext.TransportTransaction, token);
         };
 
         OnMessage returnMessage = async (messageContext, token) =>
         {
-            using var scope = logger.BeginScope("RETURN {ReceiveAddress} {NativeMessageId}", messageContext.ReceiveAddress, messageContext.NativeMessageId);
+            logger.LogInformation("RETURN {ReceiveAddress} {NativeMessageId}", messageContext.ReceiveAddress, messageContext.NativeMessageId);
             TransportOperation operation;
             try
             {
@@ -166,18 +163,17 @@ public class Service(
             {
                 throw new ConversionException("Conversion from ServiceControl failed", e);
             }
-
             await messageDispatcher.Dispatch(new TransportOperations(operation), messageContext.TransportTransaction, token);
         };
 
         foreach (var receiverSetting in receiverSettings)
         {
-            OnMessage onMessage = receiverSetting.Id == "Return"
+            var onMessage = receiverSetting.Id == "Return"
                 ? returnMessage
                 : forwardMessage;
 
             var receiver = infrastructure.Receivers[receiverSetting.Id];
-            await receiver.Initialize(new PushRuntimeSettings(),
+            await receiver.Initialize(PushRuntimeSettings.Default,
                 onMessage: (context, token) => onMessage(context, token),
                 onError: async (context, token) =>
                 {
@@ -197,24 +193,22 @@ public class Service(
                             context.Message.Headers,
                             context.Message.Body
                         );
-                        var address = new UnicastAddressTag(configuration.ErrorQueue);
+                        var address = new UnicastAddressTag(configuration.PoisonQueue);
                         var operation = new TransportOperation(poisonMessage, address);
                         var operations = new TransportOperations(operation);
 
                         await messageDispatcher.Dispatch(operations, context.TransportTransaction, token);
                         return ErrorHandleResult.Handled;
                     }
-                    else
-                    {
-                        // Exponential back-off with jitter
-                        var millisecondsDelay = (int)Math.Min(30000, 100 * Math.Pow(2, context.ImmediateProcessingFailures));
-                        millisecondsDelay += Random.Shared.Next(millisecondsDelay / 5);
 
-                        logger.LogWarning(context.Exception, "Retrying message {QueueName}, attempt {ImmediateProcessingFailures} of {MaxRetries} after {millisecondsDelay} milliseconds", configuration.ErrorQueue, context.ImmediateProcessingFailures, configuration.MaxRetries, millisecondsDelay);
-                        await Task.Delay(millisecondsDelay, token);
-                        return ErrorHandleResult.RetryRequired;
-                    }
-                }, cancellationToken: cancellationToken);
+                    // Exponential back-off with jitter
+                    var millisecondsDelay = (int)Math.Min(30000, 100 * Math.Pow(2, context.ImmediateProcessingFailures));
+                    millisecondsDelay += Random.Shared.Next(millisecondsDelay / 5);
+
+                    logger.LogWarning(context.Exception, "Retrying message {QueueName}, attempt {ImmediateProcessingFailures} of {MaxRetries} after {millisecondsDelay} milliseconds", configuration.ErrorQueue, context.ImmediateProcessingFailures, configuration.MaxRetries, millisecondsDelay);
+                    await Task.Delay(millisecondsDelay, token);
+                    return ErrorHandleResult.RetryRequired;
+                }, cancellationToken);
 
             await receiver.StartReceive(cancellationToken);
         }
@@ -222,34 +216,11 @@ public class Service(
 
     async Task StopReceiving(CancellationToken cancellationToken)
     {
-        var i = infrastructure;
-        if (i == null)
+        if (infrastructure != null)
         {
-            return;
+            var tasks = infrastructure.Receivers.Select(pair => pair.Value.StopReceive(cancellationToken));
+            await Task.WhenAll(tasks);
+            await infrastructure.Shutdown(cancellationToken);
         }
-        infrastructure = null;
-
-        // Behavior copied from https://github.com/Particular/NServiceBus/blob/9.2.3/src/NServiceBus.Core/Receiving/ReceiveComponent.cs#L229-L246
-        var receivers = i.Receivers.Values;
-        var receiverStopTasks = receivers.Select(async receiver =>
-        {
-            try
-            {
-                logger.LogDebug("Stopping {ReceiverId} receiver", receiver.Id);
-                await receiver.StopReceive(cancellationToken);
-                logger.LogDebug("Stopped {ReceiverId} receiver", receiver.Id);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                // Host is terminating
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Receiver {ReceiverId} threw an exception on stopping.", receiver.Id);
-            }
-        });
-
-        await Task.WhenAll(receiverStopTasks);
-        await i.Shutdown(cancellationToken);
     }
 }


### PR DESCRIPTION
I noticed we were getting an error logged at startup and also when the queue names changed while running.

```
2024-12-19 15:16:52 <6>Service[0] Changes detected, restarting
2024-12-19 15:16:52 <4>Service[0] Receiver Return threw an exception on stopping. System.NullReferenceException: Object reference not set to an instance of an object.    at NServiceBus.Transport.AzureServiceBus.MessagePump.StopReceive(CancellationToken cancellationToken) in /_/src/Transport/Receiving/MessagePump.cs:line 218    at NServiceBus.Transport.AzureServiceBus.MessagePump.StopReceive(CancellationToken cancellationToken) in /_/src/Transport/Receiving/MessagePump.cs:line 238    at Service.<>c__DisplayClass20_0.<<StopReceiving>b__0>d.MoveNext() in /_/src/ServiceControl.Connector.MassTransit/Service.cs:line 282
2024-12-19 15:16:52 <6>Service[0] listening to: billorder_error
```



This PR cleans up the `Service` start and stop logic for the queues.