### PR TITLE
Using the extra chiesel image for docker

### DIFF
--- a/Container-README.md
+++ b/Container-README.md
@@ -1,4 +1,4 @@
-# Particular Software ServiceControl MassTransit connector
+# MassTransit Connector for ServiceControl
 
 An extension to [ServiceControl](https://docs.particular.net/servicecontrol) that adds support for processing [MassTransit](https://masstransit.io/) failures with the [Particular Platform](https://particular.net/service-platform). This extension makes all the recoverability features for managing message processing failures; like (group) retrying, message editing and failed message inspection; available to the MassTransit community.  
 
@@ -174,7 +174,7 @@ ServiceControl primary queue by default listens to `Particular.ServiceControl` q
 
 Default: None
 
-Required when using RabbitMQ and error queues need to be dynamically resolved as queue information is queried on the broker to determine which error queues to listen to.
+RabbitMQ management API url when RabbitMQ is selected as transport.
 
 Example:
 

--- a/src/ServiceControl.Connector.MassTransit.Host/Dockerfile
+++ b/src/ServiceControl.Connector.MassTransit.Host/Dockerfile
@@ -8,7 +8,7 @@ ENV CI=true
 RUN dotnet publish src/ServiceControl.Connector.MassTransit.Host/ServiceControl.Connector.MassTransit.Host.csproj --configuration Release --arch $TARGETARCH --output /build
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/runtime:8.0-noble-chiseled
+FROM mcr.microsoft.com/dotnet/runtime:8.0-noble-chiseled-extra
 ARG VERSION=0.0.1
 ARG SHA=unknown
 ARG CREATED=2000-01-01T00:00:00Z
@@ -24,7 +24,7 @@ LABEL org.opencontainers.image.revision=$SHA
 LABEL org.opencontainers.image.created=$CREATED
 LABEL org.opencontainers.image.title="MassTransit Connector for ServiceControl"
 LABEL org.opencontainers.image.description="An extension to ServiceControl that adds support for processing MassTransit failures with the Particular Platform."
-LABEL org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/runtime:8.0-noble-chiseled
+LABEL org.opencontainers.image.base.name=mcr.microsoft.com/dotnet/runtime:8.0-noble-chiseled-extra
 
 COPY --from=build ./build /app
 


### PR DESCRIPTION
This is to prevent issues from running the image in non-US locales.