### PR TITLE
Specify current context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Build and push image to GitHub container registry
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
           platforms: linux/amd64,linux/arm64
           sbom: true


### PR DESCRIPTION
Otherwise, it uses the git URL, which won't include all git history.

This causes issues with MinVer.

I found out about this issue when making the same changes in ServiceControl.
This PR is related to https://github.com/Particular/ServiceControl.Connector.MassTransit/pull/182