### PR TITLE
No point in checking for Dependabot PRs anymore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ env:
   DOTNET_NOLOGO: true
 jobs:
   container:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
After the switch from Dependabot to Renovate, Renovate has the secrets to create signed Windows installers and other artifacts, so there's no need to check for the Dependabot actor which would not have those secrets.